### PR TITLE
numpy: Fix deprecated imresize

### DIFF
--- a/assignment1/numpy.ipynb
+++ b/assignment1/numpy.ipynb
@@ -871,7 +871,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "img = misc.face()\n",
-    "img = skimage.transform.resize(img, (720, 960))\n",
+    "img = transform.resize(img, (720, 960))\n",
     "plt.imshow(img)\n",
     "plt.show()\n",
     "\n",

--- a/assignment1/numpy.ipynb
+++ b/assignment1/numpy.ipynb
@@ -867,10 +867,11 @@
    "outputs": [],
    "source": [
     "from scipy import misc\n",
+    "import skimage\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "img = misc.face()\n",
-    "img = misc.imresize(img, (720, 960))\n",
+    "img = skimage.transform.resize(img, (720, 960))\n",
     "plt.imshow(img)\n",
     "plt.show()\n",
     "\n",


### PR DESCRIPTION
* Replace deprecated `imresize` with `skimage.transform.resize`

Signed-off-by: mr.Shu <mr@shu.io>